### PR TITLE
Sections printed when notes only attached to subsections

### DIFF
--- a/releasenotes/notes/subsections-5c6bcae84b1b0bbb.yaml
+++ b/releasenotes/notes/subsections-5c6bcae84b1b0bbb.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed issue where section headings were not printed in the report if notes were only attached
+    to subsections.

--- a/reno/config.py
+++ b/reno/config.py
@@ -442,6 +442,22 @@ class Config:
         }
         return options
 
+    @property
+    def parent_section(self):
+        """Get a lookup for the parent section of each section."""
+        parent_section = {section: None for section in self.sections}
+        last_section_at_level = {1: None, 2: None}
+        for section in self.sections:
+            if section.section_level == 1:
+                last_section_at_level[1] = section
+                last_section_at_level[2] = None
+            elif section.section_level == 2:
+                parent_section[section] = last_section_at_level[1]
+                last_section_at_level[2] = section
+            elif section.section_level == 3:
+                parent_section[section] = last_section_at_level[2] or last_section_at_level[1]
+        return parent_section
+
 # def parse_config_into(parsed_arguments):
 
 #         """Parse the user config onto the namespace arguments.

--- a/reno/formatter.py
+++ b/reno/formatter.py
@@ -94,6 +94,8 @@ def format_report(loader, config, versions_to_include, title=None,
             report.append('')
 
         # Add other sections.
+        section_reported = {section: False for section in config.sections}
+        parent_section = config.parent_section
         for section in config.sections:
             notes = [
                 (n, fn, sha)
@@ -102,6 +104,11 @@ def format_report(loader, config, versions_to_include, title=None,
                 for n in file_contents[fn].get(section.name, [])
             ]
             if notes:
+                report.extend(
+                    get_parent_section_headers(
+                        section, section_reported, parent_section, version_title, title, branch
+                    )
+                )
                 report.append(_section_anchor(
                     section.title, version_title, title, branch))
                 report.append('')
@@ -115,3 +122,29 @@ def format_report(loader, config, versions_to_include, title=None,
                 report.append('')
 
     return '\n'.join(report)
+
+
+def get_parent_section_headers(
+    starting_section,
+    section_reported,
+    parent_section,
+    version_title,
+    title,
+    branch,
+):
+    """Given a section, follow the hierarchy up to each parent and ensure
+    it has been reported."""
+    sections_to_report = []
+    current_section = starting_section
+    while current_section and not section_reported[current_section]:
+        sections_to_report.append(_section_anchor(current_section.title, version_title, title, branch))
+        section_reported[current_section] = True
+        current_section = parent_section.get(section)
+    headers = []
+    for section in reversed(sections_to_report):
+        headers.append(section)
+        headers.append('')
+        headers.append(section.title)
+        headers.append(section.header_underline())
+        headers.append('')
+    return headers

--- a/reno/tests/test_config.py
+++ b/reno/tests/test_config.py
@@ -207,6 +207,16 @@ class TestConfigProperties(base.TestCase):
         # Temporary directory to store our config
         self.tempdir = self.useFixture(fixtures.TempDir())
         self.c = config.Config('releasenotes')
+        self.c.override(
+            sections=[
+                ["features", "Features"],
+                ["features_sub", "Sub", 2],
+                ["features_subsub", "Subsub", 3],
+                ["bugs", "Bugs"],
+                ["bugs_sub", "Sub", 2],
+                ["documentation", "Documentation", 1]
+            ],
+        )
 
     def test_reporoot(self):
         self.c.reporoot = 'blah//'
@@ -239,3 +249,11 @@ class TestConfigProperties(base.TestCase):
                         template='i-am-a-template')
         self.assertEqual('fake_prelude_name', self.c.prelude_section_name)
         self.assertEqual('i-am-a-template', self.c.template)
+
+    def test_parent_section(self):
+        section_by_name = {section.name: section for section in self.c.sections}
+        self.assertEqual(section_by_name['features'], self.c.parent_section('features_sub'))
+        self.assertEqual(section_by_name['features_sub'], self.c.parent_section('features_subsub'))
+        self.assertEqual(section_by_name['bugs'], self.c.parent_section('bugs_sub'))
+        for section_name in ['features', 'bugs', 'documentation']:
+            self.assertIsNone(self.c.parent_section(section_name))

--- a/reno/tests/test_formatter.py
+++ b/reno/tests/test_formatter.py
@@ -201,6 +201,55 @@ class TestFormatterCustomSections(TestFormatterBase):
         assert_header("Subsubsection", "~")
 
 
+class TestFormatterSubSections(TestFormatterBase):
+    note_bodies = {
+        'note1': {
+            'prelude': 'This is the prelude.',
+        },
+        'note2': {
+            'features_subsubsection': [
+                'This is a subsubsection feature.',
+            ],
+        },
+        'note3': {
+            'features_subsection': [
+                'This is a subsection feature.',
+            ],
+        },
+    }
+
+    def setUp(self):
+        super(TestFormatterCustomSections, self).setUp()
+        self.c.override(sections=[
+            ['features', 'New Features'],
+            ['features_subsection', 'Subsection', 2],
+            ['features_subsubsection', 'Subsubsection', 3],
+            ['api', 'API Changes'],
+        ])
+
+    def test_custom_section_order(self):
+        result = formatter.format_report(
+            loader=self.ldr,
+            config=self.c,
+            versions_to_include=self.versions,
+            title=None,
+        )
+        prelude_pos = result.index('This is the prelude.')
+        api_pos = result.index('API Changes')
+        features_pos = result.index('New Features')
+        features_subsection_pos = result.index('Subsection')
+        features_subsubsection_pos = result.index('Subsubsection')
+        expected = [
+            prelude_pos,
+            features_pos,
+            features_subsection_pos,
+            features_subsubsection_pos,
+            api_pos,
+        ]
+        actual = sorted(expected)
+        self.assertEqual(expected, actual)
+
+
 class TestFormatterCustomUnreleaseTitle(TestFormatterBase):
 
     note_bodies = {


### PR DESCRIPTION
Updated formatter to also print section heading when notes are only attached to subsections or subsubsections.